### PR TITLE
feat: add semi-automatic exporters for wechat and zhihu

### DIFF
--- a/autowriter_text/__init__.py
+++ b/autowriter_text/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "7.1"
+__version__ = "7.2.1"

--- a/autowriter_text/pipeline/postprocess.py
+++ b/autowriter_text/pipeline/postprocess.py
@@ -1,0 +1,68 @@
+"""导出阶段使用的查询函数与数据结构。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from autowriter_text.db import ensure_schema, get_connection
+from autowriter_text.logging import logger
+
+
+@dataclass(slots=True)
+class ArticleRow:
+    """简化后的文章记录，供导出模块消费。"""
+
+    id: int
+    title: str
+    role_name: str
+    keyword_term: str
+    content_md: str
+    created_at: str
+    content_hash: str | None
+
+
+def collect_articles_for_date(date_str: str) -> List[ArticleRow]:
+    """按日期收集最多 5 篇文章，保留导出所需字段。"""
+
+    # 验证日期格式，捕捉输入错误。
+    datetime.strptime(date_str, "%Y-%m-%d")
+    with get_connection() as conn:
+        ensure_schema(conn)
+        cursor = conn.execute(
+            """
+            SELECT
+                a.id,
+                a.title,
+                r.name AS role_name,
+                k.term AS keyword_term,
+                a.content AS content_md,
+                COALESCE(a.created_at, '') AS created_at,
+                a.content_hash
+            FROM articles AS a
+            JOIN roles AS r ON r.id = a.role_id
+            JOIN keywords AS k ON k.id = a.keyword_id
+            WHERE date(a.created_at) = ?
+            ORDER BY a.created_at ASC, a.id ASC
+            LIMIT 5
+            """,
+            (date_str,),
+        )
+        rows = [
+            ArticleRow(
+                id=row["id"],
+                title=row["title"],
+                role_name=row["role_name"],
+                keyword_term=row["keyword_term"],
+                content_md=row["content_md"],
+                created_at=row["created_at"],
+                content_hash=row["content_hash"],
+            )
+            for row in cursor.fetchall()
+        ]
+    logger.info("收集文章 %s 篇用于导出", len(rows))
+    return rows
+
+
+__all__ = ["ArticleRow", "collect_articles_for_date"]

--- a/autowriter_text/smoke_test.py
+++ b/autowriter_text/smoke_test.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 from autowriter_text.generator.llm_client import generate
+from autowriter_text.pipeline.postprocess import ArticleRow
+
+from exporter.common import export_index_csv_json
+from exporter.wechat_exporter import export_for_wechat
+from exporter.zhihu_exporter import export_for_zhihu
 
 
 def main() -> None:
@@ -11,6 +19,27 @@ def main() -> None:
     prompt = "请简述 AutoWriter 的设计目标。"
     result = generate(prompt)
     print(result)
+
+    # 验证导出模块可在临时目录落地 1 篇素材包。
+    article = ArticleRow(
+        id=1,
+        title="测试角色 · 测试关键词",
+        role_name="测试角色",
+        keyword_term="测试关键词",
+        content_md="示例正文\n\n- 列表项",  # 结构化 Markdown，确保转换成功。
+        created_at="2024-01-01T00:00:00",
+        content_hash="demo",
+    )
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        wechat_rows = export_for_wechat([article], tmp_path / "wechat")
+        zhihu_rows = export_for_zhihu([article], tmp_path / "zhihu")
+        export_index_csv_json(tmp_path / "wechat", wechat_rows)
+        export_index_csv_json(tmp_path / "zhihu", zhihu_rows)
+        wechat_article_dir = next(p for p in (tmp_path / "wechat").iterdir() if p.is_dir())
+        zhihu_article_dir = next(p for p in (tmp_path / "zhihu").iterdir() if p.is_dir())
+        assert (wechat_article_dir / "paste_wechat.txt").exists()
+        assert (zhihu_article_dir / "paste_zhihu.txt").exists()
 
 
 if __name__ == "__main__":

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,183 @@
+"""AutoWriter 半自动导出与剪贴板助手 CLI。"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from autowriter_text.pipeline.postprocess import ArticleRow, collect_articles_for_date
+
+from exporter.common import ensure_dir, export_index_csv_json
+from exporter.packer import bundle_all, zip_dir
+from exporter.wechat_exporter import export_for_wechat
+from exporter.zhihu_exporter import export_for_zhihu
+
+
+def _parse_date(value: str | None) -> str:
+    """解析日期字符串，默认返回当天日期。"""
+
+    if value:
+        datetime.strptime(value, "%Y-%m-%d")
+        return value
+    # 没有传入时按 UTC+0 生成日期字符串，确保跨时区稳定。
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _require_articles(date_str: str) -> list[ArticleRow]:
+    """从数据库获取文章，若为空则退出。"""
+
+    articles = collect_articles_for_date(date_str)
+    if not articles:
+        raise SystemExit(f"{date_str} 无可导出的文章，请确认生成流程是否完成。")
+    return articles
+
+
+def _export_wechat(articles: list[ArticleRow], date_str: str, base_dir: Path) -> Tuple[Path, Path]:
+    """执行公众号导出并返回日期目录与 zip 路径。"""
+
+    date_dir = ensure_dir(base_dir / date_str)
+    rows = export_for_wechat(articles, date_dir)
+    export_index_csv_json(date_dir, rows)
+    zip_path = date_dir.parent / f"wechat_{date_str}.zip"
+    zip_dir(date_dir, zip_path)
+    print(f"[wechat] 导出完成：{date_dir} -> {zip_path}")
+    return Path(date_dir), zip_path
+
+
+def _export_zhihu(articles: list[ArticleRow], date_str: str, base_dir: Path) -> Tuple[Path, Path]:
+    """执行知乎导出并返回日期目录与 zip 路径。"""
+
+    date_dir = ensure_dir(base_dir / date_str)
+    rows = export_for_zhihu(articles, date_dir)
+    export_index_csv_json(date_dir, rows)
+    zip_path = date_dir.parent / f"zhihu_{date_str}.zip"
+    zip_dir(date_dir, zip_path)
+    print(f"[zhihu] 导出完成：{date_dir} -> {zip_path}")
+    return Path(date_dir), zip_path
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    """处理 export 子命令。"""
+
+    date_str = _parse_date(args.date)
+    articles = _require_articles(date_str)
+    if args.platform == "wechat":
+        _export_wechat(articles, date_str, Path(args.out or "exports/wechat"))
+    elif args.platform == "zhihu":
+        _export_zhihu(articles, date_str, Path(args.out or "exports/zhihu"))
+    else:
+        wechat_dir, _ = _export_wechat(articles, date_str, Path("exports/wechat"))
+        zhihu_dir, _ = _export_zhihu(articles, date_str, Path("exports/zhihu"))
+        bundle_path = Path("exports") / f"bundle_all_{date_str}.zip"
+        bundle_all(wechat_dir, zhihu_dir, bundle_path)
+        print(f"[bundle] 已生成组合压缩包：{bundle_path}")
+
+
+def _iter_copy_targets(platform: str, article_dir: Path) -> Iterable[tuple[str, Path]]:
+    """返回剪贴板复制顺序。"""
+
+    if platform == "wechat":
+        return (
+            ("标题", article_dir / "title.txt"),
+            ("摘要", article_dir / "digest.txt"),
+            ("正文 HTML", article_dir / "article.html"),
+        )
+    return (
+        ("标题", article_dir / "title.txt"),
+        ("正文 Markdown", article_dir / "article.md"),
+    )
+
+
+def cmd_copy(args: argparse.Namespace) -> None:
+    """处理 copy 子命令，交互式写入剪贴板。"""
+
+    try:
+        import pyperclip
+        from pyperclip import PyperclipException
+    except ImportError as exc:  # pragma: no cover - 依赖缺失时提示用户
+        raise SystemExit("未安装 pyperclip，请先执行 pip install pyperclip") from exc
+
+    # 提前检测剪贴板是否可用，避免流程中途失败。
+    try:
+        pyperclip.copy("")
+    except PyperclipException as exc:  # pragma: no cover - 系统剪贴板不可用
+        raise SystemExit(f"无法访问系统剪贴板：{exc}") from exc
+
+    date_str = _parse_date(args.date)
+    base_dir = Path("exports/wechat" if args.platform == "wechat" else "exports/zhihu")
+    date_dir = base_dir / date_str
+    if not date_dir.exists():
+        raise SystemExit(f"未找到导出目录：{date_dir}，请先执行 export {args.platform}")
+
+    article_dirs = sorted([p for p in date_dir.iterdir() if p.is_dir()])
+    if not article_dirs:
+        raise SystemExit(f"目录 {date_dir} 下没有文章，请检查导出结果。")
+
+    index = max(1, args.index)
+    try:
+        target_dir = article_dirs[index - 1]
+    except IndexError as exc:
+        raise SystemExit(f"索引 {index} 超出范围，共有 {len(article_dirs)} 篇。") from exc
+
+    targets = list(_iter_copy_targets(args.platform, target_dir))
+    print(f"开始复制 {target_dir.name}，共 {len(targets)} 步。")
+    for label, file_path in targets:
+        if not file_path.exists():
+            raise SystemExit(f"缺少必要文件：{file_path}")
+        content = file_path.read_text(encoding="utf-8")
+        pyperclip.copy(content)
+        input(f"已复制{label} → 请粘贴到目标页面后按回车继续…")
+    print("复制流程完成，可开始下一个字段或文章。")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """构建顶级参数解析器。"""
+
+    parser = argparse.ArgumentParser(description="AutoWriter 半自动导出 CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_parser = subparsers.add_parser("export", help="导出文章素材包")
+    export_sub = export_parser.add_subparsers(dest="platform", required=True)
+
+    wechat_parser = export_sub.add_parser("wechat", help="导出微信公众号草稿")
+    wechat_parser.add_argument("--date", help="目标日期，默认当天")
+    wechat_parser.add_argument("--out", help="输出根目录，默认 exports/wechat")
+    wechat_parser.set_defaults(func=cmd_export)
+
+    zhihu_parser = export_sub.add_parser("zhihu", help="导出知乎文章")
+    zhihu_parser.add_argument("--date", help="目标日期，默认当天")
+    zhihu_parser.add_argument("--out", help="输出根目录，默认 exports/zhihu")
+    zhihu_parser.set_defaults(func=cmd_export)
+
+    all_parser = export_sub.add_parser("all", help="同时导出两个平台")
+    all_parser.add_argument("--date", help="目标日期，默认当天")
+    all_parser.set_defaults(func=cmd_export)
+
+    copy_parser = subparsers.add_parser("copy", help="逐段复制到剪贴板")
+    copy_sub = copy_parser.add_subparsers(dest="platform", required=True)
+
+    copy_wechat = copy_sub.add_parser("wechat", help="复制公众号标题/摘要/正文")
+    copy_wechat.add_argument("--date", help="目标日期，默认当天")
+    copy_wechat.add_argument("--index", type=int, default=1, help="文章序号（从 1 开始）")
+    copy_wechat.set_defaults(func=cmd_copy)
+
+    copy_zhihu = copy_sub.add_parser("zhihu", help="复制知乎标题与正文")
+    copy_zhihu.add_argument("--date", help="目标日期，默认当天")
+    copy_zhihu.add_argument("--index", type=int, default=1, help="文章序号（从 1 开始）")
+    copy_zhihu.set_defaults(func=cmd_copy)
+
+    return parser
+
+
+def main() -> None:
+    """命令行入口。"""
+
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI 入口
+    main()

--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -1,0 +1,14 @@
+"""导出模块的对外接口，封装平台导出与打包能力。"""
+
+from __future__ import annotations
+
+from .packer import bundle_all, zip_dir
+from .wechat_exporter import export_for_wechat
+from .zhihu_exporter import export_for_zhihu
+
+__all__ = [
+    "bundle_all",
+    "export_for_wechat",
+    "export_for_zhihu",
+    "zip_dir",
+]

--- a/exporter/common.py
+++ b/exporter/common.py
@@ -1,0 +1,112 @@
+"""导出流程的通用工具函数集合。"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:  # 优先使用 markdown-it-py，若未安装则回退。
+    from markdown_it import MarkdownIt
+except ImportError:  # pragma: no cover - 允许按需降级
+    MarkdownIt = None  # type: ignore[assignment]
+try:  # 备用选项：markdown2 体积小、易于安装。
+    import markdown2
+except ImportError:  # pragma: no cover
+    markdown2 = None  # type: ignore[assignment]
+
+# 初始化 Markdown 渲染器；若依赖缺失则延迟在 md_to_html 中处理。
+_MD = MarkdownIt() if MarkdownIt is not None else None
+
+
+def ensure_dir(path: str | Path) -> Path:
+    """确保目录存在并返回 Path 对象。"""
+
+    path_obj = Path(path)
+    # parents=True 递归创建目录，exist_ok 避免目录已存在时报错。
+    path_obj.mkdir(parents=True, exist_ok=True)
+    return path_obj
+
+
+def md_to_html(md_text: str) -> str:
+    """将 Markdown 文本转换为 HTML。"""
+
+    if _MD is not None:
+        # MarkdownIt 会自动处理段落、列表、标题等，适合复制到富文本编辑器。
+        return _MD.render(md_text)
+    if markdown2 is not None:
+        return markdown2.markdown(md_text)
+    # 若两种解析器均不可用，退化为用 <br> 处理换行，确保不会阻塞导出。
+    escaped = md_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return "<p>" + escaped.replace("\n\n", "</p><p>").replace("\n", "<br />") + "</p>"
+
+
+def make_digest(text: str, max_len_cn: int = 120) -> str:
+    """截取正文前 max_len_cn 个字符作为公众号摘要。"""
+
+    # 先按行拆分并去除可能出现的口号或无效提示。
+    lines = []
+    for raw_line in text.replace("\r", "").split("\n"):
+        line = raw_line.strip()
+        if not line:
+            continue  # 跳过空行。
+        if line.startswith("【角色】"):
+            continue  # 摘要无需包含角色提示语。
+        # 过滤常见的呼吁性词语，避免摘要出现“欢迎关注”等口号。
+        if re.match(r"^(欢迎|扫码|关注|喜欢|记得)", line):
+            continue
+        lines.append(line)
+    # 将处理后的行连接成一段文本；中文长度近似使用 len() 计算即可。
+    merged = "".join(lines)
+    return merged[:max_len_cn]
+
+
+def write_text(path: str | Path, content: str) -> None:
+    """以 UTF-8 写入纯文本文件。"""
+
+    path_obj = Path(path)
+    ensure_dir(path_obj.parent)
+    path_obj.write_text(content, encoding="utf-8")
+
+
+def write_json(path: str | Path, data: object) -> None:
+    """将数据以 JSON 格式写入文件，自动处理 dataclass。"""
+
+    path_obj = Path(path)
+    ensure_dir(path_obj.parent)
+    if is_dataclass(data):
+        payload = asdict(data)
+    else:
+        payload = data
+    path_obj.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def export_index_csv_json(export_dir: str | Path, rows: Sequence[dict[str, object]]) -> None:
+    """在导出目录生成 index.csv 与 index.json，方便人工检索。"""
+
+    export_path = ensure_dir(export_dir)
+    if not rows:
+        return
+    # 写入 JSON，保留所有字段。
+    write_json(export_path / "index.json", list(rows))
+    # 写入 CSV 时按 keys 顺序输出，方便使用表格软件查看。
+    fieldnames: Iterable[str] = rows[0].keys()
+    csv_path = export_path / "index.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+__all__ = [
+    "ensure_dir",
+    "export_index_csv_json",
+    "make_digest",
+    "md_to_html",
+    "write_json",
+    "write_text",
+]

--- a/exporter/packer.py
+++ b/exporter/packer.py
@@ -1,0 +1,51 @@
+"""导出目录的打包工具。"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from .common import ensure_dir
+
+
+def zip_dir(src_dir: str | Path, zip_path: str | Path) -> Path:
+    """将目录压缩为 ZIP，保持相对路径且统一换行。"""
+
+    src_path = Path(src_dir)
+    zip_file_path = Path(zip_path)
+    ensure_dir(zip_file_path.parent)
+    with zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in sorted(src_path.rglob("*")):
+            arcname = item.relative_to(src_path)
+            if item.is_dir():
+                if str(arcname):
+                    zf.write(item, arcname=str(arcname) + "/")
+                continue
+            data = item.read_bytes()
+            zf.writestr(str(arcname), data)
+    return zip_file_path
+
+
+def bundle_all(date_dir_wechat: str | Path, date_dir_zhihu: str | Path, out_zip: str | Path) -> Path:
+    """将两个平台的导出目录打包为单个 ZIP，便于一次交付。"""
+
+    wechat_path = Path(date_dir_wechat)
+    zhihu_path = Path(date_dir_zhihu)
+    out_path = Path(out_zip)
+    ensure_dir(out_path.parent)
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for base, prefix in ((wechat_path, "wechat"), (zhihu_path, "zhihu")):
+            if not base.exists():
+                continue
+            for item in sorted(base.rglob("*")):
+                arcname = Path(prefix) / item.relative_to(base)
+                if item.is_dir():
+                    if item != base:
+                        zf.write(item, arcname=str(arcname) + "/")
+                    continue
+                data = item.read_bytes()
+                zf.writestr(str(arcname), data)
+    return out_path
+
+
+__all__ = ["bundle_all", "zip_dir"]

--- a/exporter/wechat_exporter.py
+++ b/exporter/wechat_exporter.py
@@ -1,0 +1,75 @@
+"""将文章导出为微信公众号草稿所需的素材包。"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import List, Optional
+
+from autowriter_text.pipeline.postprocess import ArticleRow
+
+from .common import ensure_dir, make_digest, md_to_html, write_json, write_text
+
+# 公众号导入的操作提示，写入每篇文章目录便于人工参考。
+WECHAT_README = """# 公众号导入步骤\n\n1. 打开 https://mp.weixin.qq.com 草稿箱，新建图文消息。\n2. 复制 `title.txt` 到标题输入框。\n3. 复制 `digest.txt` 到摘要栏（系统已截断至 120 字）。\n4. 打开 `article.html`，整体复制粘贴到正文编辑器（选择源码粘贴更稳定）。\n5. 将 `images/` 目录中的图片手动上传并替换占位。\n6. 对照 `meta.json` 确认角色、关键词、创建时间无误后保存草稿。\n"""
+
+
+def _slugify(title: str) -> str:
+    """根据标题生成目录名，保留中英文并将其它字符替换为下划线。"""
+
+    slug = re.sub(r"[^\w\u4e00-\u9fff]+", "_", title)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug or "article"
+
+
+def export_for_wechat(
+    articles: List[ArticleRow],
+    out_dir: str | Path,
+    default_cover: Optional[str] = None,
+) -> List[dict[str, object]]:
+    """导出文章到指定目录，并返回索引所需的元数据列表。"""
+
+    export_path = ensure_dir(out_dir)
+    rows: List[dict[str, object]] = []
+    for idx, article in enumerate(articles, start=1):
+        slug = _slugify(article.title)
+        article_dir = ensure_dir(export_path / f"{idx:02d}_{slug}")
+        digest = make_digest(article.content_md)
+        # 逐行注释：写入标题与摘要文本，方便人工直接复制。
+        write_text(article_dir / "title.txt", article.title)
+        write_text(article_dir / "digest.txt", digest)
+        # 保存 Markdown 与 HTML，分别满足编辑器差异化需求。
+        write_text(article_dir / "article.md", article.content_md)
+        html_body = md_to_html(article.content_md)
+        write_text(article_dir / "article.html", html_body)
+        # 合并粘贴文件：按需求排列标题、摘要与 HTML 正文。
+        paste_body = "\n".join([article.title, digest, html_body])
+        write_text(article_dir / "paste_wechat.txt", paste_body)
+        # 输出导入指南与空图片目录。
+        write_text(article_dir / "README_IMPORT.md", WECHAT_README)
+        ensure_dir(article_dir / "images")
+        meta = {
+            "article": asdict(article),
+            "digest": digest,
+            "default_cover": default_cover,
+            "export_dir": str(article_dir),
+        }
+        write_json(article_dir / "meta.json", meta)
+        rows.append(
+            {
+                "platform": "wechat",
+                "article_id": article.id,
+                "title": article.title,
+                "role": article.role_name,
+                "keyword": article.keyword_term,
+                "created_at": article.created_at,
+                "content_hash": article.content_hash or "",
+                "digest": digest,
+                "dir": article_dir.name,
+            }
+        )
+    return rows
+
+
+__all__ = ["export_for_wechat"]

--- a/exporter/zhihu_exporter.py
+++ b/exporter/zhihu_exporter.py
@@ -1,0 +1,62 @@
+"""导出知乎文章所需的素材文件。"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import List
+
+from autowriter_text.pipeline.postprocess import ArticleRow
+
+from .common import ensure_dir, md_to_html, write_json, write_text
+
+ZHIHU_README = """# 知乎导入步骤\n\n1. 打开知乎写作页面，选择文章创作。\n2. 新建草稿后，将 `title.txt` 内容粘贴到标题。\n3. 打开 `article.md`，复制全文（推荐使用 Markdown 编辑器保持格式）。\n4. 在知乎编辑器中选择“Markdown 粘贴”或使用 `Ctrl+Shift+V` 粘贴纯文本，再逐段校对。\n5. 如需插图，请按 `images/` 文件名顺序手动上传。\n6. 校验 `meta.json` 中的角色、关键词与生成时间后发布或保存草稿。\n"""
+
+
+def _slugify(title: str) -> str:
+    """生成知乎导出目录名，与公众号保持一致策略。"""
+
+    slug = re.sub(r"[^\w\u4e00-\u9fff]+", "_", title)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug or "article"
+
+
+def export_for_zhihu(articles: List[ArticleRow], out_dir: str | Path) -> List[dict[str, object]]:
+    """导出知乎草稿文件并返回索引列表。"""
+
+    export_path = ensure_dir(out_dir)
+    rows: List[dict[str, object]] = []
+    for idx, article in enumerate(articles, start=1):
+        slug = _slugify(article.title)
+        article_dir = ensure_dir(export_path / f"{idx:02d}_{slug}")
+        write_text(article_dir / "title.txt", article.title)
+        write_text(article_dir / "article.md", article.content_md)
+        html_body = md_to_html(article.content_md)
+        write_text(article_dir / "article.html", html_body)
+        # 合并粘贴文件：首行标题，其余为 Markdown 正文，方便单次复制。
+        paste_body = "\n".join([article.title, article.content_md])
+        write_text(article_dir / "paste_zhihu.txt", paste_body)
+        write_text(article_dir / "README_IMPORT.md", ZHIHU_README)
+        ensure_dir(article_dir / "images")
+        meta = {
+            "article": asdict(article),
+            "export_dir": str(article_dir),
+        }
+        write_json(article_dir / "meta.json", meta)
+        rows.append(
+            {
+                "platform": "zhihu",
+                "article_id": article.id,
+                "title": article.title,
+                "role": article.role_name,
+                "keyword": article.keyword_term,
+                "created_at": article.created_at,
+                "content_hash": article.content_hash or "",
+                "dir": article_dir.name,
+            }
+        )
+    return rows
+
+
+__all__ = ["export_for_zhihu"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pyyaml==6.0.2  # YAML 配置解析
 pydantic==2.7.4  # 数据模型校验
 loguru==0.7.2  # 日志记录
 typing-extensions==4.11.0  # 新类型支持
+markdown-it-py==3.0.0  # Markdown 渲染为 HTML
+pyperclip==1.9.0  # 跨平台剪贴板复制


### PR DESCRIPTION
## Summary
- add exporter modules and CLI commands to create WeChat/Zhihu export bundles and clipboard helper workflows
- create database postprocess collector, smoke test coverage, and README instructions for semi-automatic imports

## Testing
- python -m compileall exporter cli.py autowriter_text

------
https://chatgpt.com/codex/tasks/task_e_68e5906d96988328ade69f87c0aadf57