### PR TITLE
Add local browser automation for draft delivery

### DIFF
--- a/automation/__init__.py
+++ b/automation/__init__.py
@@ -1,0 +1,7 @@
+"""浏览器自动化模块入口。"""
+
+from .cdp import connect_chrome_cdp
+from .wechat_automator import WeChatAutomator
+from .zhihu_automator import ZhihuAutomator
+
+__all__ = ["connect_chrome_cdp", "WeChatAutomator", "ZhihuAutomator"]

--- a/automation/cdp.py
+++ b/automation/cdp.py
@@ -1,0 +1,42 @@
+"""连接到本机已打开的 Chrome 浏览器（CDP）。"""
+
+from __future__ import annotations
+
+import logging
+
+from playwright.sync_api import BrowserContext, Error, sync_playwright
+
+logger = logging.getLogger("automation.cdp")
+
+
+def connect_chrome_cdp(cdp_url: str = "http://127.0.0.1:9222") -> BrowserContext:
+    """使用 CDP 连接本机 Chrome，返回可复用的浏览器上下文。"""
+
+    playwright = sync_playwright().start()
+    try:
+        # 使用 connect_over_cdp 复用已有的 Chrome，会继承登录态。
+        browser = playwright.chromium.connect_over_cdp(cdp_url)
+    except Error as exc:
+        playwright.stop()
+        # 常见错误：Chrome 未按要求带 remote debugging 参数启动。
+        raise RuntimeError(
+            "无法通过 CDP 连接 Chrome，请确认已使用 --remote-debugging-port=9222 启动并保持打开。"
+        ) from exc
+    except Exception as exc:  # pragma: no cover - Playwright 报错依赖运行环境
+        playwright.stop()
+        # 其它未知失败时提示检查网络与端口占用情况。
+        raise RuntimeError(
+            "连接 Chrome 失败，请检查 remote debugging 端口是否可达。"
+        ) from exc
+
+    if browser.contexts:
+        context = browser.contexts[0]
+    else:
+        context = browser.new_context()
+    logger.info("已通过 CDP 连接到现有 Chrome 会话：%s", cdp_url)
+    # 将 Playwright 实例挂在 context 上，便于调用方在结束后执行 stop() 释放资源。
+    setattr(context, "_automation_playwright", playwright)
+    return context
+
+
+__all__ = ["connect_chrome_cdp"]

--- a/automation/utils.py
+++ b/automation/utils.py
@@ -1,0 +1,137 @@
+"""Playwright 自动化辅助函数集合。"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, TypeVar
+
+from playwright.sync_api import Locator, Page, TimeoutError as PlaywrightTimeoutError
+
+logger = logging.getLogger("automation")
+
+T = TypeVar("T")
+
+
+def _ensure_locator(page: Page, locator: str | Locator) -> Locator:
+    """将字符串选择器转换为 Locator，便于统一处理。"""
+
+    if isinstance(locator, Locator):
+        return locator
+    return page.locator(locator)
+
+
+def _slugify_filename(name: str) -> str:
+    """粗略地将标题转换为文件名，避免截图路径包含特殊字符。"""
+
+    sanitized = "".join(ch if ch.isalnum() else "_" for ch in name)
+    sanitized = "_".join(part for part in sanitized.split("_") if part)
+    return sanitized or "automation"
+
+
+def wait_and_fill(page: Page, selector: str | Locator, text: str, *, timeout: int = 15000) -> None:
+    """等待元素出现后填入文本，兼容 input 与 textarea。"""
+
+    target = _ensure_locator(page, selector)
+    logger.debug("等待填写输入框 %s", selector)
+    target.wait_for(state="visible", timeout=timeout)
+    target.fill("")
+    target.fill(text)
+
+
+def wait_and_type_rich(page: Page, locator: str | Locator, text_md_or_html: str) -> None:
+    """在富文本区域输入内容，自动区分 Markdown 与 HTML。"""
+
+    target = _ensure_locator(page, locator)
+    target.wait_for(state="visible", timeout=20000)
+    target.click()
+    handle = target.element_handle(timeout=2000)
+    if handle is None:
+        raise RuntimeError("富文本区域未找到有效元素句柄")
+    # HTML 内容走粘贴事件；否则直接插入文本保持 Markdown 格式。
+    content = text_md_or_html or ""
+    if "<" in content and ">" in content:
+        logger.debug("尝试通过粘贴事件写入 HTML 内容")
+        try:
+            page.evaluate(
+                "(el, html) => {"
+                "  el.focus();"
+                "  try {"
+                "    const data = new DataTransfer();"
+                "    data.setData('text/html', html);"
+                "    const evt = new ClipboardEvent('paste', {clipboardData: data});"
+                "    el.dispatchEvent(evt);"
+                "    return;"
+                "  } catch (err) {"
+                "    console.warn('DataTransfer 粘贴失败', err);"
+                "  }"
+                "  const ok = document.execCommand('insertHTML', false, html);"
+                "  if (!ok) { el.innerHTML = html; }"
+                "}",
+                handle,
+                content,
+            )
+            return
+        except Exception:
+            logger.exception("HTML 写入失败，继续以纯文本插入")
+    page.keyboard.insert_text(content)
+
+
+def safe_click(page: Page, selector: str | Locator, *, timeout: int = 10000) -> bool:
+    """仅在元素存在时点击，失败时自动截图。"""
+
+    target = _ensure_locator(page, selector)
+    try:
+        target.wait_for(state="attached", timeout=timeout)
+        target.click()
+        return True
+    except PlaywrightTimeoutError:
+        logger.debug("未在超时时间内找到可点击元素：%s", selector)
+        return False
+    except Exception as exc:  # pragma: no cover - Playwright 异常依赖环境
+        logger.warning("点击元素 %s 失败：%s", selector, exc)
+        save_screenshot(page, f"click_error_{_slugify_filename(str(selector))}.png")
+        raise
+
+
+def save_screenshot(page: Page, filename: str | None = None) -> Path:
+    """保存当前页面截图到 automation_logs 目录并返回路径。"""
+
+    date_dir = Path("automation_logs") / datetime.now().strftime("%Y-%m-%d")
+    date_dir.mkdir(parents=True, exist_ok=True)
+    if filename is None:
+        filename = f"automation_{int(time.time())}.png"
+    path = date_dir / filename
+    try:
+        page.screenshot(path=path, full_page=True)
+    except Exception as exc:  # pragma: no cover - 依赖浏览器环境
+        logger.error("保存截图失败：%s", exc)
+    return path
+
+
+def retry(fn: Callable[[], T], *, tries: int = 3, delay_s: float = 1.5) -> T:
+    """带指数退避的重试封装，便于处理偶发的网络抖动。"""
+
+    last_exc: Exception | None = None
+    for attempt in range(1, tries + 1):
+        try:
+            return fn()
+        except Exception as exc:  # pragma: no cover - 异常因环境而异
+            last_exc = exc
+            if attempt == tries:
+                raise
+            sleep_time = delay_s * (2 ** (attempt - 1))
+            logger.warning("第 %s 次尝试失败：%s，将在 %.1f 秒后重试", attempt, exc, sleep_time)
+            time.sleep(sleep_time)
+    raise last_exc  # pragma: no cover - 理论上不会执行
+
+
+__all__ = [
+    "retry",
+    "safe_click",
+    "save_screenshot",
+    "wait_and_fill",
+    "wait_and_type_rich",
+]

--- a/automation/wechat_automator.py
+++ b/automation/wechat_automator.py
@@ -1,0 +1,156 @@
+"""微信公众号草稿自动化流程。"""
+
+from __future__ import annotations
+
+import logging
+
+from playwright.sync_api import BrowserContext, Frame, Page, TimeoutError as PlaywrightTimeoutError
+
+from autowriter_text.pipeline.postprocess import ArticleRow
+
+from .utils import retry, safe_click, save_screenshot, wait_and_fill
+
+logger = logging.getLogger("automation.wechat")
+
+_WECHAT_HOME = "https://mp.weixin.qq.com/"
+_WECHAT_EDITOR = "https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit&action=edit"
+
+
+class WeChatAutomator:
+    """负责将导出的文章送入公众号草稿箱。"""
+
+    def __init__(self, context: BrowserContext) -> None:
+        self._context = context
+
+    def create_draft(self, article: ArticleRow, *, screenshot_prefix: str | None = None) -> str:
+        """为指定文章创建草稿并返回结果描述。"""
+
+        def _task() -> str:
+            page = self._context.new_page()
+            try:
+                return self._create_draft(page, article, screenshot_prefix=screenshot_prefix)
+            finally:
+                page.close()
+
+        return retry(_task, tries=3, delay_s=2.0)
+
+    def _create_draft(self, page: Page, article: ArticleRow, *, screenshot_prefix: str | None) -> str:
+        logger.info("[wechat] 开始创建草稿：%s", article.title)
+        page.set_default_timeout(20000)
+        page.goto(_WECHAT_HOME, wait_until="domcontentloaded")
+        if self._detect_manual_verification(page, article.title):
+            raise RuntimeError("公众号后台需要人工验证或扫码登录，请处理后重试。")
+        page.goto(_WECHAT_EDITOR, wait_until="domcontentloaded")
+        self._dismiss_popups(page)
+        self._fill_title(page, article)
+        self._fill_content(page, article)
+        self._save_draft(page, article, screenshot_prefix)
+        return "保存草稿成功"
+
+    def _detect_manual_verification(self, page: Page, title: str) -> bool:
+        """检测是否进入验证码/扫码页面，若是则截图提醒人工处理。"""
+
+        keywords = ["安全验证", "扫码登录", "请扫码登录", "验证登录"]
+        for word in keywords:
+            locator = page.locator(f"text={word}")
+            try:
+                if locator.first.is_visible(timeout=1000):
+                    path = save_screenshot(page, f"wechat_verify_{self._slug(title)}.png")
+                    logger.error("检测到验证页面，已保存截图：%s", path)
+                    return True
+            except PlaywrightTimeoutError:
+                continue
+        return False
+
+    def _dismiss_popups(self, page: Page) -> None:
+        """尝试关闭常见的引导与权限弹窗。"""
+
+        for text in ["知道了", "确定", "继续访问", "允许"]:
+            safe_click(page, f"text={text}", timeout=2000)
+
+    def _fill_title(self, page: Page, article: ArticleRow) -> None:
+        """多策略定位标题输入框。"""
+
+        selectors = [
+            "textarea[placeholder*='标题']",
+            "textarea[aria-label*='标题']",
+            "input[placeholder*='标题']",
+            "input[aria-label*='标题']",
+        ]
+        for selector in selectors:
+            try:
+                wait_and_fill(page, selector, article.title)
+                return
+            except PlaywrightTimeoutError:
+                continue
+        raise RuntimeError("未能找到公众号标题输入框，请检查页面结构是否变更。")
+
+    def _fill_content(self, page: Page, article: ArticleRow) -> None:
+        """向富文本编辑器写入 HTML 正文。"""
+
+        editor = self._locate_editor_frame(page)
+        if editor is None:
+            path = save_screenshot(page, f"wechat_editor_missing_{self._slug(article.title)}.png")
+            raise RuntimeError(f"未找到公众号编辑器，已保存截图：{path}")
+        try:
+            editor.evaluate(
+                "(html) => {"
+                "  const editable = document.querySelector('div[contenteditable="true"]') || document.body;"
+                "  if (!editable) { throw new Error('missing contenteditable'); }"
+                "  editable.focus();"
+                "  document.execCommand('selectAll', false, null);"
+                "  const ok = document.execCommand('insertHTML', false, html);"
+                "  if (!ok) { editable.innerHTML = html; }"
+                "}",
+                article.content_html,
+            )
+        except Exception as exc:
+            logger.exception("写入正文失败：%s", exc)
+            path = save_screenshot(page, f"wechat_fill_error_{self._slug(article.title)}.png")
+            raise RuntimeError(f"无法写入正文，请手动粘贴。截图：{path}") from exc
+
+    def _locate_editor_frame(self, page: Page) -> Frame | None:
+        """尝试获取公众号编辑器所在的 frame。"""
+
+        for frame in page.frames:
+            url = frame.url or ""
+            name = frame.name or ""
+            if "appmsg_edit" in url or "ueditor" in name or "editor" in name:
+                return frame
+        return None
+
+    def _save_draft(self, page: Page, article: ArticleRow, screenshot_prefix: str | None) -> None:
+        """点击保存草稿并等待成功提示。"""
+
+        button_selectors = [
+            "button:has-text('保存为草稿')",
+            "button:has-text('保存草稿')",
+            "button:has-text('保存')",
+            "text=保存草稿",
+        ]
+        for selector in button_selectors:
+            if safe_click(page, selector, timeout=5000):
+                break
+        else:
+            path = save_screenshot(page, f"wechat_save_missing_{self._slug(article.title)}.png")
+            raise RuntimeError(f"未找到保存按钮，截图：{path}")
+        success_texts = ["保存成功", "已保存至草稿箱", "保存草稿成功"]
+        for text in success_texts:
+            try:
+                page.locator(f"text={text}").first.wait_for(state="visible", timeout=15000)
+                logger.info("[wechat] 草稿保存成功：%s", article.title)
+                return
+            except PlaywrightTimeoutError:
+                continue
+        path = save_screenshot(
+            page,
+            f"{(screenshot_prefix or 'wechat')}_save_failed_{self._slug(article.title)}.png",
+        )
+        raise RuntimeError(f"未检测到保存成功提示，请查看截图：{path}")
+
+    @staticmethod
+    def _slug(title: str) -> str:
+        return "".join(ch if ch.isalnum() else "_" for ch in title)[:50] or "article"
+
+
+__all__ = ["WeChatAutomator"]

--- a/automation/zhihu_automator.py
+++ b/automation/zhihu_automator.py
@@ -1,0 +1,135 @@
+"""知乎草稿自动化流程。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from playwright.sync_api import BrowserContext, Page, TimeoutError as PlaywrightTimeoutError
+
+from autowriter_text.pipeline.postprocess import ArticleRow
+
+from .utils import retry, safe_click, save_screenshot, wait_and_fill, wait_and_type_rich
+
+logger = logging.getLogger("automation.zhihu")
+
+_ZHIHU_WRITE = "https://zhuanlan.zhihu.com/write"
+
+
+class ZhihuAutomator:
+    """将文章内容同步到知乎写作页面。"""
+
+    def __init__(self, context: BrowserContext) -> None:
+        self._context = context
+
+    def create_draft(self, article: ArticleRow, *, pause_on_login: bool = True) -> str:
+        """新建或覆盖知乎草稿，返回结果描述。"""
+
+        def _task() -> str:
+            page = self._context.new_page()
+            try:
+                return self._create_draft(page, article, pause_on_login=pause_on_login)
+            finally:
+                page.close()
+
+        return retry(_task, tries=3, delay_s=2.0)
+
+    def _create_draft(self, page: Page, article: ArticleRow, *, pause_on_login: bool) -> str:
+        logger.info("[zhihu] 开始创建草稿：%s", article.title)
+        page.set_default_timeout(20000)
+        page.goto(_ZHIHU_WRITE, wait_until="domcontentloaded")
+        if pause_on_login and self._handle_login_or_captcha(page, article.title):
+            logger.info("用户已完成登录，继续写入草稿。")
+        self._fill_title(page, article.title)
+        self._fill_content(page, article.content_md)
+        link = self._save_draft(page, article.title)
+        return link or "保存草稿成功"
+
+    def _handle_login_or_captcha(self, page: Page, title: str) -> bool:
+        """检测是否出现登录页或验证码，引导人工处理。"""
+
+        if "signin" in page.url or "login" in page.url:
+            path = save_screenshot(page, f"zhihu_login_{self._slug(title)}.png")
+            logger.warning("检测到知乎登录页面，请在浏览器内完成登录后按回车继续。截图：%s", path)
+            input("请在浏览器完成知乎登录后按回车继续…")
+            page.wait_for_timeout(1500)
+            return True
+        captcha_texts = ["验证码", "安全验证", "请完成验证"]
+        for text in captcha_texts:
+            try:
+                if page.locator(f"text={text}").first.is_visible(timeout=1000):
+                    path = save_screenshot(page, f"zhihu_captcha_{self._slug(title)}.png")
+                    logger.warning("检测到知乎验证码，请手动处理后按回车继续。截图：%s", path)
+                    input("请处理知乎验证码后按回车继续…")
+                    page.wait_for_timeout(1500)
+                    return True
+            except PlaywrightTimeoutError:
+                continue
+        return False
+
+    def _fill_title(self, page: Page, title: str) -> None:
+        """填写知乎文章标题。"""
+
+        selectors = [
+            "textarea[placeholder*='标题']",
+            "textarea[aria-label*='标题']",
+        ]
+        for selector in selectors:
+            try:
+                wait_and_fill(page, selector, title)
+                return
+            except PlaywrightTimeoutError:
+                continue
+        # 新版知乎标题可能使用 div[role="textbox"]，退化为富文本输入方式。
+        try:
+            wait_and_type_rich(page, page.locator("div[role='textbox']").first, title)
+            return
+        except Exception:
+            pass
+        raise RuntimeError("未能找到知乎标题输入框，请确认页面是否改版。")
+
+    def _fill_content(self, page: Page, markdown: str) -> None:
+        """向知乎正文区域粘贴 Markdown 内容。"""
+
+        editor_selectors = [
+            "div[role='textbox'][contenteditable='true']",
+            "div.EditorV2",
+            "textarea",
+        ]
+        for selector in editor_selectors:
+            try:
+                wait_and_type_rich(page, selector, markdown)
+                return
+            except PlaywrightTimeoutError:
+                continue
+        path = save_screenshot(page, f"zhihu_editor_missing_{self._slug(markdown[:20])}.png")
+        raise RuntimeError(f"未找到知乎正文区域，截图：{path}")
+
+    def _save_draft(self, page: Page, title: str) -> Optional[str]:
+        """点击保存按钮或等待自动保存提示。"""
+
+        candidates = [
+            "button:has-text('保存草稿')",
+            "button:has-text('返回草稿箱')",
+            "text=保存草稿",
+        ]
+        for selector in candidates:
+            if safe_click(page, selector, timeout=4000):
+                break
+        indicators = ["已自动保存", "草稿已保存", "保存成功"]
+        for text in indicators:
+            try:
+                page.locator(f"text={text}").first.wait_for(state="visible", timeout=15000)
+                logger.info("[zhihu] 草稿保存成功：%s", title)
+                return page.url
+            except PlaywrightTimeoutError:
+                continue
+        path = save_screenshot(page, f"zhihu_save_failed_{self._slug(title)}.png")
+        raise RuntimeError(f"知乎草稿保存未成功，请查看截图：{path}")
+
+    @staticmethod
+    def _slug(text: str) -> str:
+        return "".join(ch if ch.isalnum() else "_" for ch in text)[:50] or "article"
+
+
+__all__ = ["ZhihuAutomator"]

--- a/autowriter_text/pipeline/postprocess.py
+++ b/autowriter_text/pipeline/postprocess.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List
+from pathlib import Path
+from typing import Dict, List
 
 from autowriter_text.db import ensure_schema, get_connection
 from autowriter_text.logging import logger
+
+
+try:  # 优先使用 markdown-it 渲染 HTML。
+    from markdown_it import MarkdownIt
+except ImportError:  # pragma: no cover - 允许在最小依赖环境运行
+    MarkdownIt = None  # type: ignore[assignment]
+try:
+    import markdown2
+except ImportError:  # pragma: no cover
+    markdown2 = None  # type: ignore[assignment]
+
+_MD = MarkdownIt() if MarkdownIt is not None else None
 
 
 @dataclass(slots=True)
@@ -19,8 +33,47 @@ class ArticleRow:
     role_name: str
     keyword_term: str
     content_md: str
-    created_at: str
-    content_hash: str | None
+    content_html: str = ""
+    created_at: str = ""
+    content_hash: str | None = None
+    export_dirs: Dict[str, str] = field(default_factory=dict)
+
+
+def _md_to_html(md_text: str) -> str:
+    """将 Markdown 文本转换为 HTML，用于公众号粘贴。"""
+
+    if _MD is not None:
+        return _MD.render(md_text)
+    if markdown2 is not None:
+        return markdown2.markdown(md_text)
+    escaped = md_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return "<p>" + escaped.replace("\n\n", "</p><p>").replace("\n", "<br />") + "</p>"
+
+
+def _load_export_dirs(date_str: str) -> Dict[str, Dict[int, Path]]:
+    """从导出目录读取 meta.json，建立文章 ID 到目录的映射。"""
+
+    root = Path("exports")
+    mapping: Dict[str, Dict[int, Path]] = {"wechat": {}, "zhihu": {}}
+    for platform in mapping.keys():
+        base = root / platform / date_str
+        if not base.exists():
+            continue
+        for child in base.iterdir():
+            if not child.is_dir():
+                continue
+            meta_path = child / "meta.json"
+            if not meta_path.exists():
+                continue
+            try:
+                data = json.loads(meta_path.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - meta 格式异常时忽略
+                continue
+            article = data.get("article", {})
+            article_id = article.get("id")
+            if isinstance(article_id, int):
+                mapping[platform][article_id] = child
+    return mapping
 
 
 def collect_articles_for_date(date_str: str) -> List[ArticleRow]:
@@ -49,18 +102,36 @@ def collect_articles_for_date(date_str: str) -> List[ArticleRow]:
             """,
             (date_str,),
         )
-        rows = [
+        db_rows = cursor.fetchall()
+    export_dirs = _load_export_dirs(date_str)
+    rows: List[ArticleRow] = []
+    for row in db_rows:
+        article_id = row["id"]
+        platform_dirs: Dict[str, str] = {}
+        html_body = ""
+        for platform, platform_map in export_dirs.items():
+            path = platform_map.get(article_id)
+            if path is None:
+                continue
+            platform_dirs[platform] = str(path)
+            html_file = path / "article.html"
+            if not html_body and html_file.exists():
+                html_body = html_file.read_text(encoding="utf-8")
+        if not html_body:
+            html_body = _md_to_html(row["content_md"])
+        rows.append(
             ArticleRow(
-                id=row["id"],
+                id=article_id,
                 title=row["title"],
                 role_name=row["role_name"],
                 keyword_term=row["keyword_term"],
                 content_md=row["content_md"],
+                content_html=html_body,
                 created_at=row["created_at"],
                 content_hash=row["content_hash"],
+                export_dirs=platform_dirs,
             )
-            for row in cursor.fetchall()
-        ]
+        )
     logger.info("收集文章 %s 篇用于导出", len(rows))
     return rows
 

--- a/exporter/wechat_exporter.py
+++ b/exporter/wechat_exporter.py
@@ -41,7 +41,9 @@ def export_for_wechat(
         write_text(article_dir / "digest.txt", digest)
         # 保存 Markdown 与 HTML，分别满足编辑器差异化需求。
         write_text(article_dir / "article.md", article.content_md)
-        html_body = md_to_html(article.content_md)
+        html_body = (article.content_html or "").strip()
+        if not html_body:
+            html_body = md_to_html(article.content_md)
         write_text(article_dir / "article.html", html_body)
         # 合并粘贴文件：按需求排列标题、摘要与 HTML 正文。
         paste_body = "\n".join([article.title, digest, html_body])

--- a/exporter/zhihu_exporter.py
+++ b/exporter/zhihu_exporter.py
@@ -32,7 +32,9 @@ def export_for_zhihu(articles: List[ArticleRow], out_dir: str | Path) -> List[di
         article_dir = ensure_dir(export_path / f"{idx:02d}_{slug}")
         write_text(article_dir / "title.txt", article.title)
         write_text(article_dir / "article.md", article.content_md)
-        html_body = md_to_html(article.content_md)
+        html_body = (article.content_html or "").strip()
+        if not html_body:
+            html_body = md_to_html(article.content_md)
         write_text(article_dir / "article.html", html_body)
         # 合并粘贴文件：首行标题，其余为 Markdown 正文，方便单次复制。
         paste_body = "\n".join([article.title, article.content_md])


### PR DESCRIPTION
## Summary
- add a CDP connector and Playwright-based automators for WeChat and Zhihu using the existing browser session
- expose new `auto` CLI commands and enrich article metadata with HTML and export directory hints
- document the local automation workflow in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5af5ab47c83288c728305bb92db1e