### PR TITLE
feat: harden browser automation flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,16 @@ make run
    - `python cli.py auto all    --date YYYY-MM-DD [--limit 5]`
    CLI 会按顺序读取当日导出包的前 N 篇文章，通过 Playwright 连接到已登录的浏览器并自动创建草稿。
 3. 关注输出：每篇文章都会打印成功/失败状态；异常时会在 `automation_logs/YYYY-MM-DD/` 生成截图，便于排查。
+4. 若检测到登录或验证码拦截，命令行会提示“请在该浏览器完成登录后按 Enter 继续”，请切换到对应标签页完成后再回车。
+5. 每次运行会在 `automation_logs/<DATE>/summary.json` 写入结构化结果，记录成功/跳过/失败原因与截图路径。
 
 ### 常见问题
 - **页面元素找不到或保存失败**：平台 UI 改版时请参考 `automation_logs/` 内的截图，更新 `automation/` 下的选择器或流程。
 - **登录过期/出现验证码**：脚本会提示人工处理，请在对应浏览器标签页完成验证后重新执行命令。
-- **操作节奏过快**：建议在命令之间留出间隔，保持与人工操作一致，避免触发异常风控。
+- **操作节奏过快**：可通过 `--min-interval` 与 `--max-interval` 参数控制跨篇等待区间（默认 6-12 秒），`--max-retries` 指定单篇重试次数。
+- **公众号 HTML 支持范围**：正文粘贴前会执行白名单清洗，保留 `p/br/strong/em/h1-h4/blockquote/ul/ol/li/img/a/code/pre/span` 标签；`img` 仅接受 http/https 链接，若存在相对路径会插入 “TODO 请上传图片” 提示。
+- **重复保护**：自动以 RapidFuzz 对比近 14 天标题，相似度 ≥ 85 将标记为 `similar to <历史标题>` 并跳过；阈值与窗口可在 `pipeline/postprocess.py` 调整。
+- **DRY-RUN**：传入 `--dry-run` 可只验证选择器与粘贴流程，不执行保存，终端会显示 `DRY RUN ✓`。
 
 > 说明：该功能仅用于本机辅助提效，不会采集或存储账号口令。请在遵守平台服务条款与使用规范的前提下使用，避免高频、批量或异常自动化行为。
 

--- a/automation/utils.py
+++ b/automation/utils.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import logging
+import random
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, TypeVar
+from typing import Callable, Sequence, TypeVar
 
-from playwright.sync_api import Locator, Page, TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import (
+    ElementHandle,
+    Frame,
+    Locator,
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+)
 
 logger = logging.getLogger("automation")
 
@@ -18,65 +25,164 @@ T = TypeVar("T")
 def _ensure_locator(page: Page, locator: str | Locator) -> Locator:
     """将字符串选择器转换为 Locator，便于统一处理。"""
 
+    # 传入 Locator 时直接返回，避免重复创建。
     if isinstance(locator, Locator):
         return locator
+    # 其它情况统一走 page.locator，保持行为一致。
     return page.locator(locator)
+
+
+def _ensure_handle(target: Locator | ElementHandle) -> ElementHandle:
+    """将 Locator 转换为 ElementHandle，便于在 Frame 上执行脚本。"""
+
+    # Locator 时获取首个匹配元素的句柄。
+    if isinstance(target, Locator):
+        handle = target.element_handle(timeout=2000)
+        if handle is None:
+            raise RuntimeError("未能获取元素句柄用于后续操作")
+        return handle
+    # ElementHandle 直接返回，允许外部自行定位。
+    return target
 
 
 def _slugify_filename(name: str) -> str:
     """粗略地将标题转换为文件名，避免截图路径包含特殊字符。"""
 
+    # 仅保留字母与数字，其余替换为下划线，降低文件系统兼容性问题。
     sanitized = "".join(ch if ch.isalnum() else "_" for ch in name)
+    # 连续下划线压缩，保持文件名简洁。
     sanitized = "_".join(part for part in sanitized.split("_") if part)
     return sanitized or "automation"
+
+
+def human_sleep(min_s: float = 0.4, max_s: float = 1.2) -> None:
+    """在两个动作之间加入随机停顿，模拟人工节奏。"""
+
+    # 保护：最大值应不小于最小值，若不满足则取两者中的较大者。
+    high = max(min_s, max_s)
+    # 从区间内随机抽取停顿时长，避免固定节奏触发风控。
+    delay = random.uniform(min_s, high)
+    logger.debug("human sleep %.2f 秒", delay)
+    # 调用 time.sleep 实际等待。
+    time.sleep(delay)
+
+
+def scroll_into_view(page: Page | Frame, selector_or_locator: str | Locator) -> None:
+    """滚动页面使目标元素进入视窗，便于后续点击或输入。"""
+
+    # Frame 没有 locator 方法，统一从 page 对象上获取。
+    if isinstance(selector_or_locator, Locator):
+        target = selector_or_locator
+    elif isinstance(page, Frame):
+        target = page.locator(selector_or_locator)
+    else:
+        target = _ensure_locator(page, selector_or_locator)
+    # 等待元素出现，确保滚动不会抛异常。
+    target.wait_for(state="attached", timeout=10000)
+    handle = _ensure_handle(target)
+    try:
+        # Playwright 内置滚动方法，若元素本就可见也不会报错。
+        handle.scroll_into_view_if_needed(timeout=2000)
+    except Exception as exc:  # pragma: no cover - 浏览器环境相关
+        logger.debug("scroll_into_view 失败：%s", exc)
 
 
 def wait_and_fill(page: Page, selector: str | Locator, text: str, *, timeout: int = 15000) -> None:
     """等待元素出现后填入文本，兼容 input 与 textarea。"""
 
+    # 将选择器转成 Locator，以便统一调用。
     target = _ensure_locator(page, selector)
     logger.debug("等待填写输入框 %s", selector)
+    # 等待元素可见后再执行填充动作。
     target.wait_for(state="visible", timeout=timeout)
-    target.fill("")
-    target.fill(text)
+    target.fill("")  # 先清空旧值，避免残留内容。
+    target.fill(text)  # 再填入新的文本内容。
+
+
+def paste_html(editor: Locator | ElementHandle, html: str) -> None:
+    """将 HTML 内容写入富文本区域，附带 innerHTML 兜底。"""
+
+    # 将传入目标统一转换为 ElementHandle 以执行 DOM 操作。
+    handle = _ensure_handle(editor)
+    # owner_frame 可定位到对应的 Frame，便于处理 iframe 编辑器。
+    frame = handle.owner_frame()
+    if frame is None:
+        raise RuntimeError("无法确定富文本所在的 Frame")
+    # 执行脚本：focus + execCommand('insertHTML')，失败则回退到 innerHTML。
+    frame.evaluate(
+        "(el, html) => {"
+        "  el.focus();"  # 聚焦编辑区域，确保后续命令生效。
+        "  document.execCommand('selectAll', false, null);"  # 选中原有内容便于覆盖。
+        "  const ok = document.execCommand('insertHTML', false, html);"  # 首选官方接口。
+        "  if (!ok) {"
+        "    // 注意：直接赋值 innerHTML 会失去事件监听，仅作为兜底使用。"
+        "    el.innerHTML = html;"
+        "  }"
+        "}",
+        handle,
+        html or "",
+    )
+
+
+def insert_markdown(editor: Page | Frame | Locator | ElementHandle, md_text: str, chunk: int = 800) -> None:
+    """以小块插入方式输入 Markdown，降低编辑器一次性粘贴失败概率。"""
+
+    # 允许直接传入 Page/Frame，便于调用方灵活控制。
+    if isinstance(editor, Page):
+        # Page 级别时默认定位到 body，适配大多数富文本实现。
+        target = editor.locator("body")
+    elif isinstance(editor, Frame):
+        # Frame 与 Page 类似，同样定位 body。
+        target = editor.locator("body")
+    else:
+        # 传入 Locator/ElementHandle 时直接复用调用方结果。
+        target = editor
+    # 将目标统一转换成 ElementHandle，便于后续 focus 操作。
+    handle = _ensure_handle(target) if isinstance(target, Locator) else target
+    frame = handle.owner_frame()
+    if frame is None:
+        raise RuntimeError("未能获取 Markdown 编辑区域所属的 Frame")
+    page = frame.page
+    if page is None:
+        raise RuntimeError("未能获取所属页面用于键盘输入")
+    # 聚焦并清理历史内容，确保从空白状态开始输入。
+    handle.scroll_into_view_if_needed(timeout=2000)
+    frame.evaluate(
+        "(el) => {"
+        "  el.focus();"
+        "  document.execCommand('selectAll', false, null);"
+        "  document.execCommand('delete', false, null);"
+        "}",
+        handle,
+    )
+    # 将文本拆分为较小的块，避免一次 insert_text 过大导致丢字符。
+    text = md_text or ""
+    for start in range(0, len(text), max(1, chunk)):
+        piece = text[start : start + max(1, chunk)]
+        page.keyboard.insert_text(piece)
+        # 每次插入后暂停片刻，模拟人工逐段输入。
+        human_sleep(0.12, 0.28)
 
 
 def wait_and_type_rich(page: Page, locator: str | Locator, text_md_or_html: str) -> None:
     """在富文本区域输入内容，自动区分 Markdown 与 HTML。"""
 
+    # 先获取定位器并等待其可见。
     target = _ensure_locator(page, locator)
     target.wait_for(state="visible", timeout=20000)
     target.click()
     handle = target.element_handle(timeout=2000)
     if handle is None:
         raise RuntimeError("富文本区域未找到有效元素句柄")
-    # HTML 内容走粘贴事件；否则直接插入文本保持 Markdown 格式。
     content = text_md_or_html or ""
     if "<" in content and ">" in content:
         logger.debug("尝试通过粘贴事件写入 HTML 内容")
         try:
-            page.evaluate(
-                "(el, html) => {"
-                "  el.focus();"
-                "  try {"
-                "    const data = new DataTransfer();"
-                "    data.setData('text/html', html);"
-                "    const evt = new ClipboardEvent('paste', {clipboardData: data});"
-                "    el.dispatchEvent(evt);"
-                "    return;"
-                "  } catch (err) {"
-                "    console.warn('DataTransfer 粘贴失败', err);"
-                "  }"
-                "  const ok = document.execCommand('insertHTML', false, html);"
-                "  if (!ok) { el.innerHTML = html; }"
-                "}",
-                handle,
-                content,
-            )
+            paste_html(handle, content)
             return
-        except Exception:
+        except Exception:  # pragma: no cover - 依赖真实页面结构
             logger.exception("HTML 写入失败，继续以纯文本插入")
-    page.keyboard.insert_text(content)
+    insert_markdown(handle, content)
 
 
 def safe_click(page: Page, selector: str | Locator, *, timeout: int = 10000) -> bool:
@@ -84,6 +190,13 @@ def safe_click(page: Page, selector: str | Locator, *, timeout: int = 10000) -> 
 
     target = _ensure_locator(page, selector)
     try:
+        # 优先滚动到视窗中，避免被遮挡导致点击失败。
+        handle = target.element_handle(timeout=timeout)
+        if handle is not None:
+            try:
+                handle.scroll_into_view_if_needed(timeout=1500)
+            except Exception:  # pragma: no cover - 滚动失败不影响主流程
+                pass
         target.wait_for(state="attached", timeout=timeout)
         target.click()
         return True
@@ -99,19 +212,47 @@ def safe_click(page: Page, selector: str | Locator, *, timeout: int = 10000) -> 
 def save_screenshot(page: Page, filename: str | None = None) -> Path:
     """保存当前页面截图到 automation_logs 目录并返回路径。"""
 
+    # 截图统一放到日期目录下，便于按天归档。
     date_dir = Path("automation_logs") / datetime.now().strftime("%Y-%m-%d")
     date_dir.mkdir(parents=True, exist_ok=True)
     if filename is None:
         filename = f"automation_{int(time.time())}.png"
     path = date_dir / filename
     try:
+        # full_page=True 便于排查页面整体状态。
         page.screenshot(path=path, full_page=True)
     except Exception as exc:  # pragma: no cover - 依赖浏览器环境
         logger.error("保存截图失败：%s", exc)
     return path
 
 
-def retry(fn: Callable[[], T], *, tries: int = 3, delay_s: float = 1.5) -> T:
+def preflight_check(page: Page, expected_patterns: Sequence[str]) -> bool:
+    """检查页面是否包含预期文案，用于判断是否完成登录或进入正确页面。"""
+
+    # 遍历关键字，任意一个可见即视为预检通过。
+    for text in expected_patterns:
+        locator = page.locator(f"text={text}")
+        try:
+            if locator.first.is_visible(timeout=1500):
+                return True
+        except PlaywrightTimeoutError:
+            continue
+    try:
+        # 若元素不可见，再退化为全文本检索降低误判率。
+        body_text = page.inner_text("body", timeout=2000)
+    except Exception:
+        body_text = ""
+    normalized = body_text.replace("\n", "")
+    return any(pattern in normalized for pattern in expected_patterns)
+
+
+def retry(
+    fn: Callable[[], T],
+    *,
+    tries: int = 3,
+    delay_s: float = 1.5,
+    backoff: float = 1.8,
+) -> T:
     """带指数退避的重试封装，便于处理偶发的网络抖动。"""
 
     last_exc: Exception | None = None
@@ -122,16 +263,22 @@ def retry(fn: Callable[[], T], *, tries: int = 3, delay_s: float = 1.5) -> T:
             last_exc = exc
             if attempt == tries:
                 raise
-            sleep_time = delay_s * (2 ** (attempt - 1))
+            # 根据 backoff 指数衰减生成下一次重试的等待时长。
+            sleep_time = delay_s * (backoff ** (attempt - 1))
             logger.warning("第 %s 次尝试失败：%s，将在 %.1f 秒后重试", attempt, exc, sleep_time)
             time.sleep(sleep_time)
     raise last_exc  # pragma: no cover - 理论上不会执行
 
 
 __all__ = [
+    "human_sleep",
+    "insert_markdown",
+    "paste_html",
+    "preflight_check",
     "retry",
     "safe_click",
     "save_screenshot",
+    "scroll_into_view",
     "wait_and_fill",
     "wait_and_type_rich",
 ]

--- a/automation/wechat_automator.py
+++ b/automation/wechat_automator.py
@@ -3,17 +3,95 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from typing import Iterable
 
-from playwright.sync_api import BrowserContext, Frame, Page, TimeoutError as PlaywrightTimeoutError
+from bs4 import BeautifulSoup
+from playwright.sync_api import BrowserContext, Locator, Page, TimeoutError as PlaywrightTimeoutError
 
 from autowriter_text.pipeline.postprocess import ArticleRow
 
-from .utils import retry, safe_click, save_screenshot, wait_and_fill
+from .utils import (
+    human_sleep,
+    paste_html,
+    preflight_check,
+    retry,
+    safe_click,
+    save_screenshot,
+    scroll_into_view,
+    wait_and_fill,
+)
 
 logger = logging.getLogger("automation.wechat")
 
 _WECHAT_HOME = "https://mp.weixin.qq.com/"
-_WECHAT_EDITOR = "https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit&action=edit"
+
+
+@dataclass(slots=True)
+class AutomationFlowError(RuntimeError):
+    """用于携带截图路径的异常类型。"""
+
+    screenshot: str | None = None
+
+
+def sanitize_for_wechat(html: str) -> str:
+    """使用白名单规则清洗 HTML，确保公众号编辑器兼容。"""
+
+    # 解析 HTML 时使用 html.parser，兼容性最佳且无需额外依赖。
+    soup = BeautifulSoup(html or "", "html.parser")
+    allowed_tags = {
+        "p",
+        "br",
+        "strong",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "blockquote",
+        "ul",
+        "ol",
+        "li",
+        "img",
+        "a",
+        "code",
+        "pre",
+        "span",
+    }
+    allowed_attrs: dict[str, set[str]] = {
+        "a": {"href", "title", "target", "rel"},
+        "img": {"src", "alt"},
+        "span": {"class"},
+        "code": {"class"},
+        "pre": {"class"},
+    }
+    # 遍历所有标签，处理白名单与属性控制。
+    for tag in list(soup.find_all(True)):
+        if tag.name not in allowed_tags:
+            if tag.name in {"script", "style", "iframe"}:
+                tag.decompose()
+            else:
+                tag.unwrap()
+            continue
+        allowed = allowed_attrs.get(tag.name, set())
+        for attr in list(tag.attrs.keys()):
+            if attr not in allowed:
+                del tag.attrs[attr]
+        if tag.name == "a":
+            tag.attrs.setdefault("target", "_blank")
+            tag.attrs.setdefault("rel", "noopener")
+        if tag.name == "img":
+            src = tag.get("src", "")
+            if not src or not src.startswith(("http://", "https://")):
+                placeholder = soup.new_tag("p")
+                placeholder.string = "[TODO] 请手动上传图片并替换此处"
+                tag.replace_with(placeholder)
+                continue
+        if tag.name in {"p", "span"} and not tag.get_text(strip=True) and not tag.find("img"):
+            tag.decompose()
+    # 移除多余的空行与空白，保持 HTML 紧凑。
+    cleaned = str(soup).replace("\u200b", "").strip()
+    return cleaned
 
 
 class WeChatAutomator:
@@ -22,135 +100,236 @@ class WeChatAutomator:
     def __init__(self, context: BrowserContext) -> None:
         self._context = context
 
-    def create_draft(self, article: ArticleRow, *, screenshot_prefix: str | None = None) -> str:
-        """为指定文章创建草稿并返回结果描述。"""
+    def create_draft(
+        self,
+        article: ArticleRow,
+        *,
+        screenshot_prefix: str | None = None,
+        dry_run: bool = False,
+        max_retries: int = 3,
+    ) -> dict[str, object]:
+        """尝试创建草稿，失败时返回结构化结果。"""
 
+        result = {
+            "ok": False,
+            "platform": "wechat",
+            "title": article.title,
+            "reason": "",
+            "screenshot": "",
+        }
+
+        # 内部任务：每次重试都新开页面，避免上一轮残留状态干扰。
         def _task() -> str:
             page = self._context.new_page()
+            page.set_default_timeout(25000)
             try:
-                return self._create_draft(page, article, screenshot_prefix=screenshot_prefix)
+                return self._create_draft(page, article, screenshot_prefix, dry_run)
             finally:
                 page.close()
 
-        return retry(_task, tries=3, delay_s=2.0)
+        try:
+            # 使用带指数退避的 retry 包装，增强稳定性。
+            reason = retry(_task, tries=max_retries, delay_s=2.0, backoff=1.8)
+        except AutomationFlowError as exc:
+            result["reason"] = str(exc)
+            if exc.screenshot:
+                result["screenshot"] = exc.screenshot
+        except Exception as exc:  # pragma: no cover - Playwright 行为依赖环境
+            result["reason"] = str(exc)
+        else:
+            result["ok"] = True
+            result["reason"] = reason
+        return result
 
-    def _create_draft(self, page: Page, article: ArticleRow, *, screenshot_prefix: str | None) -> str:
+    def _create_draft(
+        self,
+        page: Page,
+        article: ArticleRow,
+        screenshot_prefix: str | None,
+        dry_run: bool,
+    ) -> str:
         logger.info("[wechat] 开始创建草稿：%s", article.title)
-        page.set_default_timeout(20000)
+        try:
+            # 预检：确保账号已登录，必要时提示人工介入。
+            self._ensure_logged_in(page, article.title)
+            # 打开「新建图文」编辑页。
+            self._open_editor(page, article.title)
+            # 关闭干扰弹窗，确保输入框可操作。
+            self._dismiss_popups(page)
+            # 填写标题，先清空再输入。
+            self._fill_title(page, article.title)
+            # 对正文做白名单清洗后写入。
+            cleaned = sanitize_for_wechat(article.content_html)
+            self._fill_content(page, article.title, cleaned)
+            if dry_run:
+                # dry-run 模式下不执行保存，直接返回提示。
+                return "DRY RUN ✓"
+            # 点击保存草稿并等待 Toast。
+            self._save_draft(page, article.title, screenshot_prefix)
+            return "保存草稿成功"
+        except AutomationFlowError:
+            raise
+        except Exception as exc:  # pragma: no cover - 页面结构可能变化
+            path = save_screenshot(page, f"wechat_unhandled_{self._slug(article.title)}.png")
+            raise AutomationFlowError(
+                f"公众号草稿创建异常，请查看截图：{path}", screenshot=str(path)
+            ) from exc
+
+    def _ensure_logged_in(self, page: Page, title: str) -> None:
+        # 访问公众号首页，判断是否已进入后台。
         page.goto(_WECHAT_HOME, wait_until="domcontentloaded")
-        if self._detect_manual_verification(page, article.title):
-            raise RuntimeError("公众号后台需要人工验证或扫码登录，请处理后重试。")
-        page.goto(_WECHAT_EDITOR, wait_until="domcontentloaded")
-        self._dismiss_popups(page)
-        self._fill_title(page, article)
-        self._fill_content(page, article)
-        self._save_draft(page, article, screenshot_prefix)
-        return "保存草稿成功"
+        patterns = ["新建图文", "写新图文", "图文素材"]
+        if preflight_check(page, patterns):
+            return
+        # 未登录时保存截图并提示人工操作。
+        path = save_screenshot(page, f"wechat_login_{self._slug(title)}.png")
+        logger.warning("未检测到公众号后台登录状态，截图：%s", path)
+        input("请在浏览器中完成登录后按回车继续…")
+        page.wait_for_timeout(1000)
+        # 完成登录后再尝试进入首页。
+        page.goto(_WECHAT_HOME, wait_until="domcontentloaded")
+        if not preflight_check(page, patterns):
+            raise AutomationFlowError(
+                "公众号后台仍未检测到登录状态，请重试。", screenshot=str(path)
+            )
 
-    def _detect_manual_verification(self, page: Page, title: str) -> bool:
-        """检测是否进入验证码/扫码页面，若是则截图提醒人工处理。"""
-
-        keywords = ["安全验证", "扫码登录", "请扫码登录", "验证登录"]
-        for word in keywords:
-            locator = page.locator(f"text={word}")
+    def _open_editor(self, page: Page, title: str) -> None:
+        # 多策略定位「新建图文」按钮，兼容不同布局。
+        selectors = [
+            "text=新建图文",
+            "role=button[name*='新建']",
+            "a[href*='appmsg']",
+        ]
+        for selector in selectors:
             try:
-                if locator.first.is_visible(timeout=1000):
-                    path = save_screenshot(page, f"wechat_verify_{self._slug(title)}.png")
-                    logger.error("检测到验证页面，已保存截图：%s", path)
-                    return True
+                # 滚动到按钮区域，避免被导航遮挡。
+                scroll_into_view(page, selector)
+                if safe_click(page, selector, timeout=5000):
+                    try:
+                        # 优先等待编辑器 URL 变化。
+                        page.wait_for_url("**/appmsg_edit**", timeout=15000)
+                    except PlaywrightTimeoutError:
+                        # 如 URL 未变化则至少等待网络空闲。
+                        page.wait_for_load_state("networkidle")
+                    return
             except PlaywrightTimeoutError:
                 continue
-        return False
+        path = save_screenshot(page, f"wechat_entry_{self._slug(title)}.png")
+        raise AutomationFlowError("未能打开公众号编辑器，请检查入口。", screenshot=str(path))
 
     def _dismiss_popups(self, page: Page) -> None:
-        """尝试关闭常见的引导与权限弹窗。"""
-
+        # 逐一尝试点击常见弹窗按钮。
         for text in ["知道了", "确定", "继续访问", "允许"]:
             safe_click(page, f"text={text}", timeout=2000)
 
-    def _fill_title(self, page: Page, article: ArticleRow) -> None:
-        """多策略定位标题输入框。"""
-
+    def _fill_title(self, page: Page, title: str) -> None:
+        # 通过占位符或 aria-label 匹配标题输入框。
         selectors = [
             "textarea[placeholder*='标题']",
-            "textarea[aria-label*='标题']",
             "input[placeholder*='标题']",
+            "textarea[aria-label*='标题']",
             "input[aria-label*='标题']",
         ]
         for selector in selectors:
             try:
-                wait_and_fill(page, selector, article.title)
+                scroll_into_view(page, selector)
+                wait_and_fill(page, selector, title)
+                human_sleep(0.3, 0.6)
                 return
             except PlaywrightTimeoutError:
                 continue
-        raise RuntimeError("未能找到公众号标题输入框，请检查页面结构是否变更。")
+        path = save_screenshot(page, f"wechat_title_{self._slug(title)}.png")
+        raise AutomationFlowError("未找到标题输入框，请检查页面结构。", screenshot=str(path))
 
-    def _fill_content(self, page: Page, article: ArticleRow) -> None:
-        """向富文本编辑器写入 HTML 正文。"""
-
-        editor = self._locate_editor_frame(page)
-        if editor is None:
-            path = save_screenshot(page, f"wechat_editor_missing_{self._slug(article.title)}.png")
-            raise RuntimeError(f"未找到公众号编辑器，已保存截图：{path}")
-        try:
-            editor.evaluate(
-                "(html) => {"
-                "  const editable = document.querySelector('div[contenteditable="true"]') || document.body;"
-                "  if (!editable) { throw new Error('missing contenteditable'); }"
-                "  editable.focus();"
-                "  document.execCommand('selectAll', false, null);"
-                "  const ok = document.execCommand('insertHTML', false, html);"
-                "  if (!ok) { editable.innerHTML = html; }"
-                "}",
-                article.content_html,
-            )
-        except Exception as exc:
-            logger.exception("写入正文失败：%s", exc)
-            path = save_screenshot(page, f"wechat_fill_error_{self._slug(article.title)}.png")
-            raise RuntimeError(f"无法写入正文，请手动粘贴。截图：{path}") from exc
-
-    def _locate_editor_frame(self, page: Page) -> Frame | None:
-        """尝试获取公众号编辑器所在的 frame。"""
-
+    def _locate_editor(self, page: Page) -> Locator:
+        # 先在主文档查找常见的 contenteditable 容器。
+        editor_selectors: Iterable[str] = (
+            "div[contenteditable='true']",
+            "div.editor",
+            "iframe[id*='ueditor']",
+            "iframe[src*='ueditor']",
+        )
+        for selector in editor_selectors:
+            locator = page.locator(selector).first
+            try:
+                locator.wait_for(state="attached", timeout=5000)
+            except PlaywrightTimeoutError:
+                continue
+            if "iframe" in selector:
+                # iframe 需进一步获取内部正文容器。
+                frame = locator.content_frame()
+                if frame is None:
+                    continue
+                body = frame.locator("div[contenteditable='true']").first
+                try:
+                    body.wait_for(state="visible", timeout=5000)
+                    return body
+                except PlaywrightTimeoutError:
+                    pass
+                return frame.locator("body")
+            return locator
+        # 主文档无结果时遍历所有子 frame。
         for frame in page.frames:
-            url = frame.url or ""
-            name = frame.name or ""
-            if "appmsg_edit" in url or "ueditor" in name or "editor" in name:
-                return frame
-        return None
+            if frame == page.main_frame:
+                continue
+            fallback = frame.locator("div[contenteditable='true']").first
+            try:
+                fallback.wait_for(state="visible", timeout=5000)
+                return fallback
+            except PlaywrightTimeoutError:
+                continue
+        raise AutomationFlowError("未找到公众号正文编辑区域，请手动检查。")
 
-    def _save_draft(self, page: Page, article: ArticleRow, screenshot_prefix: str | None) -> None:
-        """点击保存草稿并等待成功提示。"""
+    def _fill_content(self, page: Page, title: str, html: str) -> None:
+        try:
+            editor = self._locate_editor(page)
+        except AutomationFlowError as exc:
+            path = save_screenshot(page, f"wechat_editor_{self._slug(title)}.png")
+            raise AutomationFlowError("未找到公众号正文编辑区域，请查看截图。", screenshot=str(path)) from exc
+        try:
+            scroll_into_view(page, editor)
+        except Exception:
+            pass
+        try:
+            paste_html(editor, html)
+            human_sleep(0.5, 0.8)
+        except Exception as exc:
+            path = save_screenshot(page, f"wechat_fill_{self._slug(title)}.png")
+            raise AutomationFlowError("正文写入失败，请参考截图。", screenshot=str(path)) from exc
 
-        button_selectors = [
+    def _save_draft(self, page: Page, title: str, screenshot_prefix: str | None) -> None:
+        # 多种保存按钮选择器，兼容不同文案。
+        buttons = [
             "button:has-text('保存为草稿')",
             "button:has-text('保存草稿')",
             "button:has-text('保存')",
             "text=保存草稿",
         ]
-        for selector in button_selectors:
+        for selector in buttons:
             if safe_click(page, selector, timeout=5000):
                 break
         else:
-            path = save_screenshot(page, f"wechat_save_missing_{self._slug(article.title)}.png")
-            raise RuntimeError(f"未找到保存按钮，截图：{path}")
-        success_texts = ["保存成功", "已保存至草稿箱", "保存草稿成功"]
-        for text in success_texts:
+            path = save_screenshot(page, f"wechat_save_btn_{self._slug(title)}.png")
+            raise AutomationFlowError("未找到保存按钮，请检查页面。", screenshot=str(path))
+        # 监听包含“保存成功”等文案的提示元素。
+        confirm_texts = ["保存成功", "已保存至草稿箱", "保存草稿成功"]
+        for text in confirm_texts:
             try:
-                page.locator(f"text={text}").first.wait_for(state="visible", timeout=15000)
-                logger.info("[wechat] 草稿保存成功：%s", article.title)
+                toast = page.locator(f"text={text}")
+                toast.first.wait_for(state="visible", timeout=15000)
+                human_sleep(0.6, 1.0)
                 return
             except PlaywrightTimeoutError:
                 continue
         path = save_screenshot(
             page,
-            f"{(screenshot_prefix or 'wechat')}_save_failed_{self._slug(article.title)}.png",
+            f"{(screenshot_prefix or 'wechat')}_save_failed_{self._slug(title)}.png",
         )
-        raise RuntimeError(f"未检测到保存成功提示，请查看截图：{path}")
+        raise AutomationFlowError("未检测到保存成功提示，请查看截图。", screenshot=str(path))
 
     @staticmethod
-    def _slug(title: str) -> str:
-        return "".join(ch if ch.isalnum() else "_" for ch in title)[:50] or "article"
+    def _slug(text: str) -> str:
+        return "".join(ch if ch.isalnum() else "_" for ch in text)[:50] or "article"
 
 
-__all__ = ["WeChatAutomator"]
+__all__ = ["WeChatAutomator", "sanitize_for_wechat"]

--- a/automation/zhihu_automator.py
+++ b/automation/zhihu_automator.py
@@ -3,17 +3,35 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from dataclasses import dataclass
+from typing import Iterable
 
-from playwright.sync_api import BrowserContext, Page, TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import BrowserContext, Locator, Page, TimeoutError as PlaywrightTimeoutError
 
 from autowriter_text.pipeline.postprocess import ArticleRow
 
-from .utils import retry, safe_click, save_screenshot, wait_and_fill, wait_and_type_rich
+from .utils import (
+    human_sleep,
+    insert_markdown,
+    preflight_check,
+    retry,
+    safe_click,
+    save_screenshot,
+    scroll_into_view,
+    wait_and_fill,
+    wait_and_type_rich,
+)
 
 logger = logging.getLogger("automation.zhihu")
 
 _ZHIHU_WRITE = "https://zhuanlan.zhihu.com/write"
+
+
+@dataclass(slots=True)
+class AutomationFlowError(RuntimeError):
+    """用于捕获异常路径并携带截图信息。"""
+
+    screenshot: str | None = None
 
 
 class ZhihuAutomator:
@@ -22,110 +40,186 @@ class ZhihuAutomator:
     def __init__(self, context: BrowserContext) -> None:
         self._context = context
 
-    def create_draft(self, article: ArticleRow, *, pause_on_login: bool = True) -> str:
-        """新建或覆盖知乎草稿，返回结果描述。"""
+    def create_draft(
+        self,
+        article: ArticleRow,
+        *,
+        dry_run: bool = False,
+        max_retries: int = 3,
+    ) -> dict[str, object]:
+        """新建或覆盖知乎草稿，返回结构化结果。"""
 
+        result = {
+            "ok": False,
+            "platform": "zhihu",
+            "title": article.title,
+            "reason": "",
+            "screenshot": "",
+        }
+
+        # 内部任务：每轮重试都单独开页，避免历史状态干扰。
         def _task() -> str:
             page = self._context.new_page()
+            page.set_default_timeout(25000)
             try:
-                return self._create_draft(page, article, pause_on_login=pause_on_login)
+                return self._create_draft(page, article, dry_run)
             finally:
                 page.close()
 
-        return retry(_task, tries=3, delay_s=2.0)
+        try:
+            # 使用 retry 提高稳定性，网络抖动时自动退避。
+            reason = retry(_task, tries=max_retries, delay_s=2.0, backoff=1.8)
+        except AutomationFlowError as exc:
+            result["reason"] = str(exc)
+            if exc.screenshot:
+                result["screenshot"] = exc.screenshot
+        except Exception as exc:  # pragma: no cover - Playwright 环境相关
+            result["reason"] = str(exc)
+        else:
+            result["ok"] = True
+            result["reason"] = reason
+        return result
 
-    def _create_draft(self, page: Page, article: ArticleRow, *, pause_on_login: bool) -> str:
+    def _create_draft(self, page: Page, article: ArticleRow, dry_run: bool) -> str:
         logger.info("[zhihu] 开始创建草稿：%s", article.title)
-        page.set_default_timeout(20000)
+        try:
+            # 打开写作页面，必要时提示人工登录或过验证码。
+            self._ensure_write_page(page, article.title)
+            # 填写标题。
+            self._fill_title(page, article.title)
+            # 写入 Markdown 正文。
+            self._fill_content(page, article.content_md)
+            if dry_run:
+                # dry-run 模式不执行保存，仅验证流程。
+                return "DRY RUN ✓"
+            # 保存草稿或等待自动保存提示。
+            self._save_draft(page, article.title)
+            return "保存草稿成功"
+        except AutomationFlowError:
+            raise
+        except Exception as exc:  # pragma: no cover - 页面细节可能变化
+            path = save_screenshot(page, f"zhihu_unhandled_{self._slug(article.title)}.png")
+            raise AutomationFlowError("知乎草稿创建异常，请查看截图。", screenshot=str(path)) from exc
+
+    def _ensure_write_page(self, page: Page, title: str) -> None:
+        # 打开知乎写作页面，判断是否被重定向到登录页。
         page.goto(_ZHIHU_WRITE, wait_until="domcontentloaded")
-        if pause_on_login and self._handle_login_or_captcha(page, article.title):
-            logger.info("用户已完成登录，继续写入草稿。")
-        self._fill_title(page, article.title)
-        self._fill_content(page, article.content_md)
-        link = self._save_draft(page, article.title)
-        return link or "保存草稿成功"
-
-    def _handle_login_or_captcha(self, page: Page, title: str) -> bool:
-        """检测是否出现登录页或验证码，引导人工处理。"""
-
-        if "signin" in page.url or "login" in page.url:
+        if "login" in page.url or "signin" in page.url:
             path = save_screenshot(page, f"zhihu_login_{self._slug(title)}.png")
-            logger.warning("检测到知乎登录页面，请在浏览器内完成登录后按回车继续。截图：%s", path)
-            input("请在浏览器完成知乎登录后按回车继续…")
-            page.wait_for_timeout(1500)
-            return True
+            logger.warning("检测到知乎登录页面，截图：%s", path)
+            input("请在该浏览器完成登录后按回车继续…")
+            page.wait_for_timeout(1200)
+            page.goto(_ZHIHU_WRITE, wait_until="domcontentloaded")
+        # 检测验证码拦截。
+        patterns = ["写文章", "发布文章", "草稿箱"]
         captcha_texts = ["验证码", "安全验证", "请完成验证"]
-        for text in captcha_texts:
-            try:
-                if page.locator(f"text={text}").first.is_visible(timeout=1000):
-                    path = save_screenshot(page, f"zhihu_captcha_{self._slug(title)}.png")
-                    logger.warning("检测到知乎验证码，请手动处理后按回车继续。截图：%s", path)
-                    input("请处理知乎验证码后按回车继续…")
-                    page.wait_for_timeout(1500)
-                    return True
-            except PlaywrightTimeoutError:
-                continue
-        return False
+        if any(self._text_visible(page, text) for text in captcha_texts):
+            path = save_screenshot(page, f"zhihu_captcha_{self._slug(title)}.png")
+            logger.warning("检测到知乎验证码，截图：%s", path)
+            input("请完成验证码后按回车继续…")
+            page.wait_for_timeout(1200)
+            page.goto(_ZHIHU_WRITE, wait_until="domcontentloaded")
+        # 预检：页面中出现核心文案视为成功。
+        if not preflight_check(page, patterns):
+            path = save_screenshot(page, f"zhihu_preflight_{self._slug(title)}.png")
+            raise AutomationFlowError("知乎写作页预检失败，请人工确认。", screenshot=str(path))
+
+    def _text_visible(self, page: Page, text: str) -> bool:
+        locator = page.locator(f"text={text}")
+        try:
+            return locator.first.is_visible(timeout=1000)
+        except PlaywrightTimeoutError:
+            return False
 
     def _fill_title(self, page: Page, title: str) -> None:
-        """填写知乎文章标题。"""
-
+        # 优先使用 textarea/input 类型的标题输入框。
         selectors = [
             "textarea[placeholder*='标题']",
-            "textarea[aria-label*='标题']",
+            "[data-testid*='PostEditor-Title'] textarea",
+            "input[placeholder*='标题']",
         ]
         for selector in selectors:
             try:
+                scroll_into_view(page, selector)
                 wait_and_fill(page, selector, title)
+                human_sleep(0.3, 0.6)
                 return
             except PlaywrightTimeoutError:
                 continue
-        # 新版知乎标题可能使用 div[role="textbox"]，退化为富文本输入方式。
+        # 新版编辑器可能使用富文本 div 作为标题。
+        rich_title = page.locator("div[role='textbox']").first
         try:
-            wait_and_type_rich(page, page.locator("div[role='textbox']").first, title)
+            wait_and_type_rich(page, rich_title, title)
+            human_sleep(0.3, 0.6)
             return
-        except Exception:
-            pass
-        raise RuntimeError("未能找到知乎标题输入框，请确认页面是否改版。")
+        except Exception as exc:
+            path = save_screenshot(page, f"zhihu_title_{self._slug(title)}.png")
+            raise AutomationFlowError("未找到知乎标题输入框，请检查。", screenshot=str(path)) from exc
+
+    def _locate_editor(self, page: Page) -> Locator:
+        # 按常见容器顺序查找正文编辑器。
+        selectors: Iterable[str] = (
+            "div[contenteditable='true']",
+            "[data-testid*='PostEditor-Content']",
+            "div.EditorV2",
+        )
+        for selector in selectors:
+            locator = page.locator(selector).first
+            try:
+                locator.wait_for(state="visible", timeout=6000)
+                return locator
+            except PlaywrightTimeoutError:
+                continue
+        raise AutomationFlowError("未找到知乎正文编辑区域，请关注页面改动。")
 
     def _fill_content(self, page: Page, markdown: str) -> None:
-        """向知乎正文区域粘贴 Markdown 内容。"""
-
-        editor_selectors = [
-            "div[role='textbox'][contenteditable='true']",
-            "div.EditorV2",
-            "textarea",
-        ]
-        for selector in editor_selectors:
+        try:
+            editor = self._locate_editor(page)
+        except AutomationFlowError as exc:
+            path = save_screenshot(page, f"zhihu_editor_{self._slug(markdown[:20])}.png")
+            raise AutomationFlowError("未找到知乎正文编辑区域，请查看截图。", screenshot=str(path)) from exc
+        try:
+            scroll_into_view(page, editor)
+        except Exception:
+            pass
+        try:
+            # 先尝试一次性粘贴，最快捷。
+            editor.click()
+            editor.press("Control+A")
+            editor.press("Delete")
+            page.keyboard.insert_text(markdown)
+            human_sleep(0.5, 0.8)
+        except Exception:
+            logger.info("一次性粘贴失败，尝试分段插入 Markdown。")
             try:
-                wait_and_type_rich(page, selector, markdown)
-                return
-            except PlaywrightTimeoutError:
-                continue
-        path = save_screenshot(page, f"zhihu_editor_missing_{self._slug(markdown[:20])}.png")
-        raise RuntimeError(f"未找到知乎正文区域，截图：{path}")
+                # 分段 insert_markdown，降低失败概率。
+                insert_markdown(editor, markdown)
+            except Exception as exc:
+                path = save_screenshot(page, f"zhihu_content_{self._slug(markdown[:20])}.png")
+                raise AutomationFlowError("知乎正文写入失败，请查看截图。", screenshot=str(path)) from exc
 
-    def _save_draft(self, page: Page, title: str) -> Optional[str]:
-        """点击保存按钮或等待自动保存提示。"""
-
-        candidates = [
+    def _save_draft(self, page: Page, title: str) -> None:
+        # 先尝试显式保存按钮。
+        buttons = [
             "button:has-text('保存草稿')",
             "button:has-text('返回草稿箱')",
             "text=保存草稿",
         ]
-        for selector in candidates:
+        for selector in buttons:
             if safe_click(page, selector, timeout=4000):
+                human_sleep(0.4, 0.8)
                 break
+        # 监听提示文案，确认保存状态。
         indicators = ["已自动保存", "草稿已保存", "保存成功"]
         for text in indicators:
             try:
                 page.locator(f"text={text}").first.wait_for(state="visible", timeout=15000)
-                logger.info("[zhihu] 草稿保存成功：%s", title)
-                return page.url
+                human_sleep(0.4, 0.8)
+                return
             except PlaywrightTimeoutError:
                 continue
-        path = save_screenshot(page, f"zhihu_save_failed_{self._slug(title)}.png")
-        raise RuntimeError(f"知乎草稿保存未成功，请查看截图：{path}")
+        path = save_screenshot(page, f"zhihu_save_{self._slug(title)}.png")
+        raise AutomationFlowError("知乎草稿保存未成功，请查看截图。", screenshot=str(path))
 
     @staticmethod
     def _slug(text: str) -> str:

--- a/exporter/zhihu_exporter.py
+++ b/exporter/zhihu_exporter.py
@@ -9,7 +9,7 @@ from typing import List
 
 from autowriter_text.pipeline.postprocess import ArticleRow
 
-from .common import ensure_dir, md_to_html, write_json, write_text
+from .common import ensure_dir, md_to_html, normalize_title, write_json, write_text
 
 ZHIHU_README = """# 知乎导入步骤\n\n1. 打开知乎写作页面，选择文章创作。\n2. 新建草稿后，将 `title.txt` 内容粘贴到标题。\n3. 打开 `article.md`，复制全文（推荐使用 Markdown 编辑器保持格式）。\n4. 在知乎编辑器中选择“Markdown 粘贴”或使用 `Ctrl+Shift+V` 粘贴纯文本，再逐段校对。\n5. 如需插图，请按 `images/` 文件名顺序手动上传。\n6. 校验 `meta.json` 中的角色、关键词与生成时间后发布或保存草稿。\n"""
 
@@ -30,14 +30,15 @@ def export_for_zhihu(articles: List[ArticleRow], out_dir: str | Path) -> List[di
     for idx, article in enumerate(articles, start=1):
         slug = _slugify(article.title)
         article_dir = ensure_dir(export_path / f"{idx:02d}_{slug}")
-        write_text(article_dir / "title.txt", article.title)
+        title_text = normalize_title(article.title)
+        write_text(article_dir / "title.txt", title_text)
         write_text(article_dir / "article.md", article.content_md)
         html_body = (article.content_html or "").strip()
         if not html_body:
             html_body = md_to_html(article.content_md)
         write_text(article_dir / "article.html", html_body)
         # 合并粘贴文件：首行标题，其余为 Markdown 正文，方便单次复制。
-        paste_body = "\n".join([article.title, article.content_md])
+        paste_body = "\n".join([title_text, article.content_md])
         write_text(article_dir / "paste_zhihu.txt", paste_body)
         write_text(article_dir / "README_IMPORT.md", ZHIHU_README)
         ensure_dir(article_dir / "images")
@@ -50,7 +51,7 @@ def export_for_zhihu(articles: List[ArticleRow], out_dir: str | Path) -> List[di
             {
                 "platform": "zhihu",
                 "article_id": article.id,
-                "title": article.title,
+                "title": title_text,
                 "role": article.role_name,
                 "keyword": article.keyword_term,
                 "created_at": article.created_at,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ loguru==0.7.2  # 日志记录
 typing-extensions==4.11.0  # 新类型支持
 markdown-it-py==3.0.0  # Markdown 渲染为 HTML
 pyperclip==1.9.0  # 跨平台剪贴板复制
+beautifulsoup4==4.12.3  # HTML 清洗
+rapidfuzz==3.6.1  # 文本相似度计算


### PR DESCRIPTION
## Summary
- add automation utilities for human-like pacing, HTML pasting fallbacks, and preflight detection to improve browser robustness
- overhaul WeChat/Zhihu automators with login prompts, sanitized content handling, multi-strategy selectors, and structured results
- extend CLI/export pipeline with duplicate-protection, throttle and dry-run controls, normalized titles/digests, and summary logging

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_68e5c8754fcc83289f5b9184c723b206